### PR TITLE
fix: repository_dispatch에 stale github.sha 대신 실제 릴리즈 커밋 SHA 전달

### DIFF
--- a/.github/workflows/auto-version.yml
+++ b/.github/workflows/auto-version.yml
@@ -110,6 +110,10 @@ on:
         description: "증가 후 태그 (예: v1.0.3)"
         value: ${{ jobs.version.outputs.new_tag }}
 
+      new_sha:
+        description: "실제로 푸시된 릴리즈 커밋의 SHA (github.sha는 트리거 커밋에 고정되어 부정확함)"
+        value: ${{ jobs.version.outputs.new_sha }}
+
 permissions:
   contents: write
   actions: read
@@ -127,6 +131,7 @@ jobs:
       bump_level: ${{ steps.bump.outputs.bump_level }}
       new_version: ${{ steps.bump.outputs.new_version }}
       new_tag: ${{ steps.bump.outputs.new_tag }}
+      new_sha: ${{ steps.bump.outputs.new_sha }}
       plain_version_file: ${{ inputs.plain_version_file }}
 
     steps:
@@ -202,6 +207,6 @@ jobs:
                 "new_version": "${{ steps.bump.outputs.new_version }}",
                 "new_tag":     "${{ steps.bump.outputs.new_tag }}",
                 "bump_level":  "${{ steps.bump.outputs.bump_level }}",
-                "sha":         "${{ github.sha }}"
+                "sha":         "${{ steps.bump.outputs.new_sha }}"
               }
             }'

--- a/action.yml
+++ b/action.yml
@@ -71,6 +71,10 @@ outputs:
     description: "증가 후 태그 (예: v1.0.3)"
     value: ${{ steps.compute.outputs.new_tag }}
 
+  new_sha:
+    description: "실제로 푸시된 릴리즈 커밋의 SHA (github.sha는 트리거 커밋에 고정되어 부정확함)"
+    value: ${{ steps.create-tag.outputs.new_sha }}
+
   project_type:
     description: "확정된 프로젝트 타입"
     value: ${{ steps.compute.outputs.project_type }}
@@ -129,6 +133,7 @@ runs:
 
     # 태그 생성 후 푸시 + 릴리즈 커밋 푸시
     - name: Create tag & push
+      id: create-tag
       if: ${{ steps.compute.outputs.version_bumped == 'true' }}
       shell: bash
       env:

--- a/scripts/create-tag.mjs
+++ b/scripts/create-tag.mjs
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-import { buildReleaseMessage, execOut, extractVersionDescription, hasChanges, runCmd, tryExecOut } from "./utils.mjs";
+import { buildReleaseMessage, execOut, extractVersionDescription, hasChanges, runCmd, setOutput, tryExecOut } from "./utils.mjs";
 
 const tag = process.env.TAG;
 const newVersion = process.env.NEW_VERSION;
@@ -87,3 +87,9 @@ try {
   console.error('변경사항 푸시 실패: ', e?.message ?? e);
   process.exit(1);
 }
+
+// 실제로 푸시된 릴리즈 커밋의 SHA
+// github.sha는 워크플로우를 트리거한 최초 커밋에 고정되어, 이 스크립트가 새로 만든
+// 릴리즈 커밋을 반영하지 못한다. repository_dispatch 등 후속 워크플로우가 올바른
+// 커밋을 체크아웃할 수 있도록 실제 HEAD SHA를 별도로 출력한다.
+setOutput('new_sha', execOut('git rev-parse HEAD'));


### PR DESCRIPTION
## 문제
`github.sha`는 워크플로우를 트리거한 최초 커밋에 고정되는데, `Create tag & push` 단계가 그 이후에 새로운 릴리즈 커밋(버전 bump 커밋)을 만들어 푸시한다. 그 결과 `repository_dispatch`의 `client_payload.sha`가 실제로는 **bump 되기 전 커밋**을 가리키게 된다.

실제 사례 (`Chuseok22/infra-automation`):
- 릴리즈 커밋 `54fa548` (package.json 0.1.0 → 0.1.1, 태그 `v0.1.1`)이 새로 생성/푸시됨
- 하지만 dispatch된 `sha`는 그 이전 커밋 `642d733`(여전히 버전 0.1.0)
- 후속 `npm-publish` 워크플로우가 `642d733`을 체크아웃해 `package.json`을 읽었고, 결국 이미 bump된 버전이 아닌 **이전 버전(0.1.0)을 publish 시도**함

## 수정 내용
- `scripts/create-tag.mjs`: 커밋/태그 푸시가 끝난 뒤 실제 HEAD SHA(`git rev-parse HEAD`)를 `new_sha` 출력으로 노출
- `action.yml`: `Create tag & push` 스텝에 `id: create-tag` 추가, `new_sha` 출력을 액션 출력으로 연결
- `.github/workflows/auto-version.yml`: `new_sha`를 workflow_call 출력으로 노출하고, `repository_dispatch` payload의 `sha` 필드 값을 `github.sha` 대신 `steps.bump.outputs.new_sha`로 변경 (필드 이름은 그대로 유지해 기존 소비자 워크플로우와 호환)

## 참고
- 이 저장소를 `@v1`로 참조하는 다른 프로젝트에도 영향을 주므로, 태그 이동은 이 PR에 포함하지 않았습니다. 병합 후 `v1` 플로팅 태그 갱신 여부는 별도로 결정해주세요.